### PR TITLE
UPSTREAM: Update execution-environment.yml to add kubevirt.core

### DIFF
--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -4,6 +4,9 @@ images:
   base_image:
     name: quay.io/centos/centos:stream9
 dependencies:
+  python_interpreter:
+    package_system: python3.11
+    python_path: /usr/bin/python3.11
   ansible_core:
     # Require minimum of 2.15 to get ansible-inventory --limit option
     package_pip: ansible-core>=2.15.0rc2,<2.16
@@ -26,7 +29,7 @@ dependencies:
       - name: redhatinsights.insights
   system: |
     git-core [platform:rpm]
-    python3.9-devel [platform:rpm compile]
+    python3.11-devel [platform:rpm compile]
     libcurl-devel [platform:rpm compile]
     krb5-devel [platform:rpm compile]
     krb5-workstation [platform:rpm]
@@ -36,7 +39,6 @@ dependencies:
     sshpass [platform:rpm]
     rsync [platform:rpm]
     epel-release [platform:rpm]
-    python-unversioned-command [platform:rpm]
   python: |
     git+https://github.com/ansible/ansible-sign
     ncclient
@@ -57,3 +59,5 @@ additional_build_steps:
     - COPY --from=quay.io/ansible/receptor:devel /usr/bin/receptor /usr/bin/receptor
     - RUN mkdir -p /var/run/receptor
     - RUN git lfs install --system
+    # SymLink `python` -> `python3.11`
+    - RUN alternatives --install /usr/bin/python python /usr/bin/python3.11 311

--- a/execution-environment.yml
+++ b/execution-environment.yml
@@ -25,6 +25,7 @@ dependencies:
       - name: ansible.posix
       - name: ansible.windows
       - name: redhatinsights.insights
+      - name: kubevirt.core
   system: |
     git-core [platform:rpm]
     python3.9-devel [platform:rpm compile]


### PR DESCRIPTION
In order to have openshift virtualization as a inventory source we need the kubevirt.core collection added to this collection